### PR TITLE
Multiple hierarchy drilldowns

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-bootstrap/pagination": "^1.0.0",
     "lodash": "^4.14.1",
-    "mondrian-rest-client": "Datawheel/mondrian-rest-client#df9d6c28abb0112a5a46ff791c57473bba3078c8",
+    "mondrian-rest-client": "^0.1.2",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-bootstrap": "^0.32.1",

--- a/src/components/DrillDownMenu.js
+++ b/src/components/DrillDownMenu.js
@@ -7,8 +7,8 @@ import "../css/DrillDownMenu.css";
 
 import { HierarchyComponent } from "./HierarchyComponent";
 
-export default function DrillDownMenu(props, context) {
-  const { cube, drillDowns, dispatch } = props,
+export default function DrillDownMenu(props) {
+  const { cube, dispatch } = props,
     dimensions = cube ? cube.dimensions : [];
 
   return (

--- a/src/components/DrillDownMenu.js
+++ b/src/components/DrillDownMenu.js
@@ -5,6 +5,8 @@ import { DropdownButton } from "react-bootstrap";
 import { addDrilldown } from "../redux/reducers/aggregation";
 import "../css/DrillDownMenu.css";
 
+import { HierarchyComponent } from "./HierarchyComponent";
+
 export default function DrillDownMenu(props, context) {
   const { cube, drillDowns, dispatch } = props,
     dimensions = cube ? cube.dimensions : [];
@@ -20,17 +22,14 @@ export default function DrillDownMenu(props, context) {
       {dimensions.map((d, i) => (
         <li key={i} className="dropdown-submenu">
           <a tabIndex="-1">{d.name}</a>
-          <ul className="dropdown-menu">
-            {d.hierarchies[0].levels
-              .slice(d.hierarchies[0].allMemberName ? 1 : 0)
-              .map((l, j) => (
-                <li key={`${i}.${j}`} onClick={() => dispatch(addDrilldown(l))}>
-                  <a tabIndex="-1">
-                    {drillDowns.find(dd => dd === l) ? "✓ " : " "}
-                    {l.name}
-                  </a>
-                </li>
-              ))}
+          <ul className="dropdown-menu" key={d.name}>
+            {d.hierarchies.map((hierarchy, hIdx) => (
+              <HierarchyComponent
+                hierarchy={hierarchy}
+                key={hIdx}
+                clickEvent={level => dispatch(addDrilldown(level))}
+              />
+            ))}
           </ul>
         </li>
       ))}

--- a/src/components/HierarchyComponent.js
+++ b/src/components/HierarchyComponent.js
@@ -1,18 +1,21 @@
-import React from 'react';
+import React from "react";
 
 export const HierarchyComponent = props => {
-  const {hierarchy, clickEvent} = props;
+  const { hierarchy, clickEvent } = props;
   const name = hierarchy.name;
-  const levels = hierarchy.levels.slice(hierarchy.allMemberName ? 1 : 0)
-    return (
-      <li className="dropdown-submenu"><a tabIndex="-1">{ name }</a>
+  const levels = hierarchy.levels.slice(hierarchy.allMemberName ? 1 : 0);
+  return (
+    <li className="dropdown-submenu">
+      <a tabIndex="-1">{name}</a>
       <ul className="dropdown-menu">
-        {
-          levels.map((level, levelIdx) => {
-            return <li onClick={() => clickEvent(level)} key={levelIdx}><a tabIndex="-1">{ level.name }</a></li>
-          })
-        }
+        {levels.map((level, levelIdx) => {
+          return (
+            <li onClick={() => clickEvent(level)} key={levelIdx}>
+              <a tabIndex="-1">{level.name}</a>
+            </li>
+          );
+        })}
       </ul>
-      </li>
-    )
-}
+    </li>
+  );
+};

--- a/src/components/HierarchyComponent.js
+++ b/src/components/HierarchyComponent.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export const HierarchyComponent = props => {
+  const {hierarchy, clickEvent} = props;
+  const name = hierarchy.name;
+  const levels = hierarchy.levels.slice(hierarchy.allMemberName ? 1 : 0)
+    return (
+      <li className="dropdown-submenu"><a tabIndex="-1">{ name }</a>
+      <ul className="dropdown-menu">
+        {
+          levels.map((level, levelIdx) => {
+            return <li onClick={() => clickEvent(level)} key={levelIdx}><a tabIndex="-1">{ level.name }</a></li>
+          })
+        }
+      </ul>
+      </li>
+    )
+}

--- a/src/components/HierarchyComponent.js
+++ b/src/components/HierarchyComponent.js
@@ -4,6 +4,13 @@ export const HierarchyComponent = props => {
   const { hierarchy, clickEvent } = props;
   const name = hierarchy.name;
   const levels = hierarchy.levels.slice(hierarchy.allMemberName ? 1 : 0);
+  if (levels.length === 1) {
+    return (
+      <li onClick={() => clickEvent(levels[0])} key={0}>
+        <a tabIndex="-1">{levels[0].name}</a>
+      </li>
+    );
+  }
   return (
     <li className="dropdown-submenu">
       <a tabIndex="-1">{name}</a>


### PR DESCRIPTION
Adds support for drilling down multiple hierarchies within the same dimension
<img width="644" alt="screen shot 2018-04-13 at 10 56 25 am" src="https://user-images.githubusercontent.com/87581/38742013-5b2f89a0-3f09-11e8-908d-940bcc8a561a.png">

(the next step will be to add cuts for multiple hierarchies within a single dimensions)