### PR TITLE
Fix React TypeError

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -91,7 +91,11 @@ function DataTable(props) {
     var sortAccessor;
 
     if (dataTable.sortIndex < cntDims) {
-      sortAccessor = d => d[dataTable.sortIndex]["caption"];
+      sortAccessor = d => d[dataTable.sortIndex];
+
+      if (typeof sortAccessor !== "undefined") {
+        sortAccessor = sortAccessor["caption"];
+      }
     } else {
       sortAccessor = d => d[dataTable.sortIndex];
     }

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -91,10 +91,9 @@ function DataTable(props) {
     var sortAccessor;
 
     if (dataTable.sortIndex < cntDims) {
-      sortAccessor = d => d[dataTable.sortIndex];
-
-      if (typeof sortAccessor !== "undefined") {
-        sortAccessor = sortAccessor["caption"];
+      sortAccessor = d => {
+        const accessor = d[dataTable.sortIndex];
+        return accessor ? accessor["caption"] : accessor;
       }
     } else {
       sortAccessor = d => d[dataTable.sortIndex];

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -152,7 +152,9 @@ function DataTable(props) {
                     {row.map((cell, j) => (
                       <td key={j} className={j >= cntDims ? "measureCell" : ""}>
                         {j < cntDims
-                          ? cell.caption
+                          ? typeof cell === "undefined"
+                            ? ""
+                            : cell.caption
                           : typeof cell === "number"
                             ? cell.toLocaleString()
                             : cell}


### PR DESCRIPTION
This simply adds a blank string when the `cell` variable is undefined, which means no label was returned from the database and an error was going to be returned instead. 

This is especially important for the OEC database, where we don't currently have labels for every single HS6 product code.